### PR TITLE
Add real estate agent, rate limiting and Sentry

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -102,3 +102,13 @@ TAVILY_API_KEY=[YOUR_TAVILY_API_KEY]  # Get your API key at: https://app.tavily.
 
 # Your Supabase project's anonymous (public) key.
 # NEXT_PUBLIC_SUPABASE_ANON_KEY=[YOUR_NEXT_PUBLIC_SUPABASE_ANON_KEY]
+# ------------------------------
+# Rate Limiting Configuration
+# ------------------------------
+RATE_LIMIT_WINDOW=60000  # Time window in ms
+RATE_LIMIT_MAX=60        # Requests per IP per window
+
+# ------------------------------
+# Error Monitoring (Sentry)
+# ------------------------------
+SENTRY_DSN=[YOUR_SENTRY_DSN]

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,11 +5,14 @@ import { ThemeProvider } from '@/components/theme-provider'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { Toaster } from '@/components/ui/sonner'
 import { createClient } from '@/lib/supabase/server'
-import { cn } from '@/lib/utils'
+import { cn, initSentry } from '@/lib/utils'
 import { Analytics } from '@vercel/analytics/next'
 import type { Metadata, Viewport } from 'next'
 import { Inter as FontSans } from 'next/font/google'
 import './globals.css'
+
+// Initialize error monitoring
+initSentry()
 
 const fontSans = FontSans({
   subsets: ['latin'],

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -220,3 +220,24 @@ SERPER_API_KEY=[YOUR_API_KEY]
 ```bash
 JINA_API_KEY=[YOUR_API_KEY]
 ```
+
+### Rate Limiting
+
+Set limits on API requests using the built-in middleware. Configure the window and maximum number of requests per IP:
+
+```bash
+RATE_LIMIT_WINDOW=60000  # 1 minute window
+RATE_LIMIT_MAX=60        # Max requests per window
+```
+
+### Error Monitoring
+
+Provide a Sentry DSN to enable error tracking:
+
+```bash
+SENTRY_DSN=[YOUR_SENTRY_DSN]
+```
+
+### SearXNG Limiter
+
+The `searxng-limiter.toml` file controls request limits for your self-hosted SearXNG instance. Adjust the values to throttle abusive traffic.

--- a/lib/agents/index.ts
+++ b/lib/agents/index.ts
@@ -1,0 +1,1 @@
+export { realEstateResearcher } from './real-estate-researcher'

--- a/lib/agents/real-estate-researcher.ts
+++ b/lib/agents/real-estate-researcher.ts
@@ -1,0 +1,47 @@
+import { CoreMessage, smoothStream, streamText } from 'ai'
+import { createQuestionTool } from '../tools/question'
+import { retrieveTool } from '../tools/retrieve'
+import { createSearchTool } from '../tools/search'
+import { createVideoSearchTool } from '../tools/video-search'
+import { getModel } from '../utils/registry'
+
+const REAL_ESTATE_PROMPT = `
+You are a helpful real estate assistant with access to web search, content retrieval and video search tools.
+Focus on providing information about property details, valuations, market trends and home buying advice.
+Keep responses concise and cite sources using the [number](url) format.
+`
+
+type ResearcherReturn = Parameters<typeof streamText>[0]
+
+export function realEstateResearcher({
+  messages,
+  model,
+  searchMode
+}: {
+  messages: CoreMessage[]
+  model: string
+  searchMode: boolean
+}): ResearcherReturn {
+  const currentDate = new Date().toLocaleString()
+
+  const searchTool = createSearchTool(model)
+  const videoSearchTool = createVideoSearchTool(model)
+  const askQuestionTool = createQuestionTool(model)
+
+  return {
+    model: getModel(model),
+    system: `${REAL_ESTATE_PROMPT}\nCurrent date and time: ${currentDate}`,
+    messages,
+    tools: {
+      search: searchTool,
+      retrieve: retrieveTool,
+      videoSearch: videoSearchTool,
+      ask_question: askQuestionTool
+    },
+    experimental_activeTools: searchMode
+      ? ['search', 'retrieve', 'videoSearch', 'ask_question']
+      : [],
+    maxSteps: searchMode ? 5 : 1,
+    experimental_transform: smoothStream()
+  }
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -255,3 +255,5 @@ export function convertToExtendedCoreMessages(
 
   return result
 }
+export { initSentry } from './sentry'
+export { isRateLimited } from './rate-limit'

--- a/lib/utils/rate-limit.ts
+++ b/lib/utils/rate-limit.ts
@@ -1,0 +1,19 @@
+const windows = new Map<string, { count: number; start: number }>()
+
+export function isRateLimited(
+  key: string,
+  windowMs: number,
+  max: number
+): boolean {
+  const now = Date.now()
+  const entry = windows.get(key)
+  if (!entry || now - entry.start > windowMs) {
+    windows.set(key, { count: 1, start: now })
+    return false
+  }
+  if (entry.count >= max) {
+    return true
+  }
+  entry.count += 1
+  return false
+}

--- a/lib/utils/sentry.ts
+++ b/lib/utils/sentry.ts
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/nextjs'
+
+let initialized = false
+
+export function initSentry() {
+  if (initialized) return
+
+  const dsn = process.env.SENTRY_DSN
+  if (!dsn) return
+
+  Sentry.init({
+    dsn,
+    tracesSampleRate: 1.0
+  })
+
+  initialized = true
+}

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "rehype-katex": "^6.0.0",
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
+    "@sentry/nextjs": "^7.100.0",
     "sonner": "^1.4.41",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",

--- a/searxng-limiter.toml
+++ b/searxng-limiter.toml
@@ -1,1 +1,7 @@
-#https://docs.searxng.org/admin/searx.limiter.html
+# SearXNG rate limiter configuration
+[server]
+limiter = true
+
+[limits]
+search = "60/minute"
+engines = "10/minute"


### PR DESCRIPTION
## Summary
- add new real estate researcher agent
- implement simple rate limiter for API routes
- integrate Sentry for error monitoring
- document new env vars and add defaults
- provide sample SearXNG limiter configuration

## Testing
- `npm run lint` *(fails: next not found)*