### PR TITLE
Add SearXNG limiter defaults

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -109,6 +109,17 @@ engines:
 
 For detailed configuration options, refer to the [SearXNG documentation](https://docs.searxng.org/admin/settings/settings.html#settings-yml)
 
+#### Adjusting Rate Limits
+
+Request throttling is controlled by the `searxng-limiter.toml` file. Enable the
+limiter by setting `SEARXNG_LIMITER=true` in your `.env.local`. Each limit uses
+the `requests/time` format (for example `60/minute`). After editing the file
+restart the service to apply the new limits:
+
+```bash
+docker-compose restart searxng
+```
+
 #### Troubleshooting
 
 - If specific search engines aren't working, try disabling them in `searxng-settings.yml`

--- a/searxng-limiter.toml
+++ b/searxng-limiter.toml
@@ -1,1 +1,21 @@
-#https://docs.searxng.org/admin/searx.limiter.html
+# Example rate limiting configuration for SearXNG
+# See https://docs.searxng.org/admin/searx.limiter.html
+
+# Ban settings - IPs that violate limits are banned for one hour
+[ban]
+duration = "1h"
+# Number of infractions before a ban is applied
+threshold = 5
+
+# Request limits. Each value uses the form "requests/time".
+[limits.search]
+# Maximum searches allowed from a single IP
+rates = ["5/second", "60/minute"]
+
+[limits.suggest]
+# Suggestions endpoint has a lower limit
+rates = ["10/minute"]
+
+[limits.global]
+# Overall limit for any request type
+rates = ["120/hour", "1000/day"]


### PR DESCRIPTION
## Summary
- add default limiter values in `searxng-limiter.toml`
- describe how to change rate limits in `docs/CONFIGURATION.md`

## Testing
- `bun x next lint` *(fails: ConnectionRefused downloading package manifest)*