### PR TITLE
Fix speech recognition types and Raleway font

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,7 @@ import { createClient } from '@/lib/supabase/server'
 import { cn } from '@/lib/utils'
 import { Analytics } from '@vercel/analytics/next'
 import type { Metadata, Viewport } from 'next'
-import { Roboto as FontSans } from 'next/font/google'
+import { Raleway as FontSans } from 'next/font/google'
 import './globals.css'
 
 const fontSans = FontSans({

--- a/speech.d.ts
+++ b/speech.d.ts
@@ -1,0 +1,8 @@
+interface SpeechRecognition {
+  continuous: boolean;
+  lang: string;
+  onresult: ((this: SpeechRecognition, ev: any) => any) | null;
+  onend: (() => void) | null;
+  start(): void;
+  stop(): void;
+}


### PR DESCRIPTION
## Summary
- use Raleway instead of Roboto
- add ambient `SpeechRecognition` interface for browser voice input

## Testing
- `bun test` *(passes)*
- `tsc -p tsconfig.json --noEmit` *(fails: missing modules)*